### PR TITLE
feat(job-status): expose ENV to force disabling job status tracking

### DIFF
--- a/lib/Resque/Job/Status.php
+++ b/lib/Resque/Job/Status.php
@@ -46,6 +46,7 @@ class Resque_Job_Status
 	{
 		$this->id = $id;
 		$this->prefix = empty($prefix) ? '' : "${prefix}_";
+		$this->isTracking = getenv('RESQUE_DISABLE_JOB_TRACKING') === "1" ? false: null;
 	}
 
 	/**


### PR DESCRIPTION
This should prevent unnecessary redis calls when not interested in job status tracking. Using a ENV to limit call site changes throughout.